### PR TITLE
Fix joint state for mimic joints & expose epsilon parameter

### DIFF
--- a/doc/user.md
+++ b/doc/user.md
@@ -16,6 +16,7 @@ The topic_based system interface has a few `ros2_control` urdf tags to customize
 
 * joint_commands_topic: (default: "/robot_joint_command"). Example: `<param name="joint_commands_topic">/my_topic_joint_commands</param>`.
 * joint_states_topic: (default: "/robot_joint_states"). Example: `<param name="joint_states_topic">/my_topic_joint_states</param>`.
+* trigger_joint_command_threshold: (default: 1e-5). Used to avoid spamming the joint command topic when the difference between the current joint state and the joint command is small than this value, set to zero to always send the joint command. Example: `<param name="trigger_joint_command_threshold">0.001</param>`.
 
 #### Per-joint Parameters
 

--- a/include/topic_based_ros2_control/topic_based_system.hpp
+++ b/include/topic_based_ros2_control/topic_based_system.hpp
@@ -90,6 +90,10 @@ private:
   std::vector<double> last_position_command_;
   std::vector<std::vector<double>> joint_states_;
 
+  // If the difference between the current joint state and joint command is less than this value,
+  // the joint command will not be published.
+  double trigger_joint_command_threshold_ = 1e-5;
+
   template <typename HandleType>
   bool getInterface(const std::string& name, const std::string& interface_name, const size_t vector_index,
                     std::vector<std::vector<double>>& values, std::vector<HandleType>& interfaces);

--- a/include/topic_based_ros2_control/topic_based_system.hpp
+++ b/include/topic_based_ros2_control/topic_based_system.hpp
@@ -87,7 +87,6 @@ private:
 
   /// The size of this vector is (standard_interfaces_.size() x nr_joints)
   std::vector<std::vector<double>> joint_commands_;
-  std::vector<double> last_position_command_;
   std::vector<std::vector<double>> joint_states_;
 
   // If the difference between the current joint state and joint command is less than this value,

--- a/src/topic_based_system.cpp
+++ b/src/topic_based_system.cpp
@@ -199,6 +199,14 @@ hardware_interface::return_type TopicBasedSystem::read(const rclcpp::Time& /*tim
     }
   }
 
+  for (const auto& mimic_joint : mimic_joints_)
+  {
+    for (auto& joint_state : joint_states_)
+    {
+      joint_state[mimic_joint.joint_index] = mimic_joint.multiplier * joint_state[mimic_joint.mimicked_joint_index];
+    }
+  }
+
   return hardware_interface::return_type::OK;
 }
 

--- a/src/topic_based_system.cpp
+++ b/src/topic_based_system.cpp
@@ -60,7 +60,6 @@ CallbackReturn TopicBasedSystem::on_init(const hardware_interface::HardwareInfo&
     joint_commands_[i].resize(info_.joints.size(), 0.0);
     joint_states_[i].resize(info_.joints.size(), 0.0);
   }
-  last_position_command_.resize(info_.joints.size(), 0.0);
 
   // Initial command values
   for (auto i = 0u; i < info_.joints.size(); i++)
@@ -263,7 +262,6 @@ hardware_interface::return_type TopicBasedSystem::write(const rclcpp::Time& /*ti
   }
 
   topic_based_joint_commands_publisher_->publish(joint_state);
-  last_position_command_ = joint_state.position;
 
   return hardware_interface::return_type::OK;
 }


### PR DESCRIPTION
This PR fixes 

1- The joint states for mimic joints, previously it wasn't set
2- Expose `trigger_joint_command_threshold` to decide when to stop publishing the joint commands (setting it to 0.0 will always publish them)
3- Use the current joint state and joint command for the previous check + remove `last_joint_command_` (I have no idea why I didn't do this in the first place :D)