### PR TITLE
colcon: fixup missing test dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,7 @@ if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
   find_package(ament_lint_auto REQUIRED)
   find_package(ament_cmake_pytest REQUIRED)
+  find_package(ros2_control_test_assets REQUIRED)
 
   # ROS2 linters, but disable copyright test. PickNik's copyright's may not conform
   # to this test
@@ -65,7 +66,7 @@ if(BUILD_TESTING)
   ament_add_gtest(topic_based_system_test test/topic_based_system_test.cpp)
   target_link_libraries(topic_based_system_test
     ${PROJECT_NAME})
-  ament_target_dependencies(topic_based_system_test ${THIS_PACKAGE_INCLUDE_DEPENDS})
+  ament_target_dependencies(topic_based_system_test ${THIS_PACKAGE_INCLUDE_DEPENDS} ros2_control_test_assets)
 endif()
 
 pluginlib_export_plugin_description_file(hardware_interface topic_based_ros2_control_plugin_description.xml)


### PR DESCRIPTION
fixes ros2_control_test_assets .hpp file was not found