### PR TITLE
Enable mobile base in Isaac

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ endif()
 option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 
 set(THIS_PACKAGE_INCLUDE_DEPENDS
+  angles
   rclcpp
   hardware_interface
   sensor_msgs

--- a/doc/user.md
+++ b/doc/user.md
@@ -17,6 +17,7 @@ The topic_based system interface has a few `ros2_control` urdf tags to customize
 * joint_commands_topic: (default: "/robot_joint_command"). Example: `<param name="joint_commands_topic">/my_topic_joint_commands</param>`.
 * joint_states_topic: (default: "/robot_joint_states"). Example: `<param name="joint_states_topic">/my_topic_joint_states</param>`.
 * trigger_joint_command_threshold: (default: 1e-5). Used to avoid spamming the joint command topic when the difference between the current joint state and the joint command is smaller than this value, set to zero to always send the joint command. Example: `<param name="trigger_joint_command_threshold">0.001</param>`.
+* sum_wrapped_joint_states: (default: "false"). Used to track the total rotation for joint states the values reported on the `joint_commands_topic` wrap from 2*pi to -2*pi when rotating in the positive direction. (Isaac Sim only reports joint states from 2*pi to -2*pi) Example: `<param name="sum_wrapped_joint_states">true</param>`.
 
 #### Per-joint Parameters
 
@@ -33,6 +34,7 @@ If your robot description support mock_components you only need to change `<plug
                 <plugin>topic_based_ros2_control/TopicBasedSystem</plugin>
                 <param name="joint_commands_topic">/topic_based_joint_commands</param>
                 <param name="joint_states_topic">/topic_based_joint_states</param>
+                <param name="sum_wrapped_joint_states">true</param>
             </hardware>
             <joint name="joint_1">
                 <command_interface name="position"/>

--- a/include/topic_based_ros2_control/topic_based_system.hpp
+++ b/include/topic_based_ros2_control/topic_based_system.hpp
@@ -70,7 +70,6 @@ private:
   rclcpp::Publisher<sensor_msgs::msg::JointState>::SharedPtr topic_based_joint_commands_publisher_;
   rclcpp::Node::SharedPtr node_;
   sensor_msgs::msg::JointState latest_joint_state_;
-  sensor_msgs::msg::JointState previous_joint_state_;
   bool sum_wrapped_joint_states_{ false };
 
   /// Use standard interfaces for joints because they are relevant for dynamic behavior

--- a/include/topic_based_ros2_control/topic_based_system.hpp
+++ b/include/topic_based_ros2_control/topic_based_system.hpp
@@ -70,6 +70,8 @@ private:
   rclcpp::Publisher<sensor_msgs::msg::JointState>::SharedPtr topic_based_joint_commands_publisher_;
   rclcpp::Node::SharedPtr node_;
   sensor_msgs::msg::JointState latest_joint_state_;
+  sensor_msgs::msg::JointState previous_joint_state_;
+  bool sum_wrapped_joint_states_{ false };
 
   /// Use standard interfaces for joints because they are relevant for dynamic behavior
   std::array<std::string, 4> standard_interfaces_ = { hardware_interface::HW_IF_POSITION,

--- a/package.xml
+++ b/package.xml
@@ -16,6 +16,7 @@
 
     <buildtool_depend>ament_cmake</buildtool_depend>s
 
+    <depend>angles</depend>
     <depend>rclcpp</depend>
     <depend>hardware_interface</depend>
     <depend>sensor_msgs</depend>

--- a/package.xml
+++ b/package.xml
@@ -4,6 +4,7 @@
     <version>0.1.1</version>
     <description>ros2 control hardware interface for topic_based sim</description>
 
+    <maintainer email="marq.razz@gmail.com">Marq Rasmussen</maintainer>
     <maintainer email="jafar@picknik.ai">Jafar</maintainer>
     <author email="jafar@picknik.ai">Jafar</author>
 

--- a/src/topic_based_system.cpp
+++ b/src/topic_based_system.cpp
@@ -38,6 +38,32 @@
 #include <rclcpp/executors.hpp>
 #include <topic_based_ros2_control/topic_based_system.hpp>
 
+namespace
+{
+/** @brief Sums the total rotation for joint states that wrap from 2*pi to -2*pi
+when rotating in the positive direction */
+void sumRotationFromMinus2PiTo2Pi(const double current_wrapped_rad, const double previous_wrapped_rad,
+                                  double& total_rotation)
+{
+  double delta = current_wrapped_rad - previous_wrapped_rad;
+
+  // Check for discontinuities due to the jump from 2*pi to -2*pi and correct them
+  if (delta > M_PI)
+  {
+    // The change is large and positive, but it should be small and negative
+    delta -= 4.0 * M_PI;
+  }
+  else if (delta < -M_PI)
+  {
+    // The change is large and negative, but it should be small and positive
+    delta += 4.0 * M_PI;
+  }
+
+  // Add the corrected delta to the total rotation
+  total_rotation += delta;
+}
+}  // namespace
+
 namespace topic_based_ros2_control
 {
 
@@ -135,6 +161,13 @@ CallbackReturn TopicBasedSystem::on_init(const hardware_interface::HardwareInfo&
       get_hardware_parameter("joint_states_topic", "/robot_joint_states"), rclcpp::SensorDataQoS(),
       [this](const sensor_msgs::msg::JointState::SharedPtr joint_state) { latest_joint_state_ = *joint_state; });
 
+  // if the values on the `joint_states_topic` are wrapped between -2*pi and 2*pi (like they are in Isaac Sim)
+  // sum the total joint rotation returned on the `joint_states_` interface
+  if (get_hardware_parameter("sum_wrapped_joint_states", "false") == "true")
+  {
+    sum_wrapped_joint_states_ = true;
+  }
+
   return CallbackReturn::SUCCESS;
 }
 
@@ -182,6 +215,13 @@ std::vector<hardware_interface::CommandInterface> TopicBasedSystem::export_comma
 hardware_interface::return_type TopicBasedSystem::read(const rclcpp::Time& /*time*/, const rclcpp::Duration& /*period*/)
 {
   rclcpp::spin_some(node_);
+
+  // initialize the previous_joint_state on the first read()
+  if (previous_joint_state_.position.size() != latest_joint_state_.position.size())
+  {
+    previous_joint_state_ = latest_joint_state_;
+  }
+
   for (std::size_t i = 0; i < latest_joint_state_.name.size(); ++i)
   {
     const auto& joints = info_.joints;
@@ -191,7 +231,15 @@ hardware_interface::return_type TopicBasedSystem::read(const rclcpp::Time& /*tim
     if (it != joints.end())
     {
       auto j = static_cast<std::size_t>(std::distance(joints.begin(), it));
-      joint_states_[POSITION_INTERFACE_INDEX][j] = latest_joint_state_.position[i];
+      if (sum_wrapped_joint_states_)
+      {
+        sumRotationFromMinus2PiTo2Pi(latest_joint_state_.position[i], previous_joint_state_.position[i],
+                                     joint_states_[POSITION_INTERFACE_INDEX][j]);
+      }
+      else
+      {
+        joint_states_[POSITION_INTERFACE_INDEX][j] = latest_joint_state_.position[i];
+      }
       if (!latest_joint_state_.velocity.empty())
       {
         joint_states_[VELOCITY_INTERFACE_INDEX][j] = latest_joint_state_.velocity[i];
@@ -202,6 +250,8 @@ hardware_interface::return_type TopicBasedSystem::read(const rclcpp::Time& /*tim
       }
     }
   }
+  // update the previous_joint_state_
+  previous_joint_state_ = latest_joint_state_;
 
   for (const auto& mimic_joint : mimic_joints_)
   {
@@ -247,9 +297,27 @@ hardware_interface::return_type TopicBasedSystem::write(const rclcpp::Time& /*ti
   {
     joint_state.name.push_back(info_.joints[i].name);
     joint_state.header.stamp = node_->now();
-    joint_state.position.push_back(joint_commands_[POSITION_INTERFACE_INDEX][i]);
-    joint_state.velocity.push_back(joint_commands_[VELOCITY_INTERFACE_INDEX][i]);
-    joint_state.effort.push_back(joint_commands_[EFFORT_INTERFACE_INDEX][i]);
+    // only send commands to the interfaces that are defined for this joint
+    for (auto interface : info_.joints[i].command_interfaces)
+    {
+      if (interface.name == hardware_interface::HW_IF_POSITION)
+      {
+        joint_state.position.push_back(joint_commands_[POSITION_INTERFACE_INDEX][i]);
+      }
+      else if (interface.name == hardware_interface::HW_IF_VELOCITY)
+      {
+        joint_state.velocity.push_back(joint_commands_[VELOCITY_INTERFACE_INDEX][i]);
+      }
+      else if (interface.name == hardware_interface::HW_IF_EFFORT)
+      {
+        joint_state.effort.push_back(joint_commands_[EFFORT_INTERFACE_INDEX][i]);
+      }
+      else
+      {
+        RCLCPP_WARN_ONCE(node_->get_logger(), "Joint '%s' has unsupported command interfaces found: %s.",
+                         info_.joints[i].name.c_str(), interface.name.c_str());
+      }
+    }
   }
 
   for (const auto& mimic_joint : mimic_joints_)


### PR DESCRIPTION
This PR enables `TopicBasedSystem` to work with mobile bases in Isaac. 

Joints in Isaac report a state between -2pi and 2pi which causes issues when running Nav2 and reporting odometry. This PR adds the ability to track the total rotation of each joint by specifying the parameter `<param name="sum_wrapped_joint_states">true</param>` in your robots ros2_controlxacro.

I also fixed an issue where `TopicBasedSystem` would send commands to all interfaces. That is when I claimed the velocity interface of a joint it would also send position commands (which had a zero value when publishing to Isaac causing it not to move). Now it only sends commands to the `command_interfaces` defined in your ros2_control.xacro.

https://github.com/MarqRazz/c3pzero/assets/25058794/35301ba1-e443-44ff-b6ba-0fabae138205