### PR TITLE
Allow publisher to always publish by setting the threshold to zero.

### DIFF
--- a/src/topic_based_system.cpp
+++ b/src/topic_based_system.cpp
@@ -270,7 +270,7 @@ hardware_interface::return_type TopicBasedSystem::write(const rclcpp::Time& /*ti
       joint_states_[POSITION_INTERFACE_INDEX].cbegin(), joint_states_[POSITION_INTERFACE_INDEX].cend(),
       joint_commands_[POSITION_INTERFACE_INDEX].cbegin(), 0.0,
       [](const auto d1, const auto d2) { return std::abs(d1) + std::abs(d2); }, std::minus<double>{});
-  if (diff <= trigger_joint_command_threshold_)
+  if (diff < trigger_joint_command_threshold_)
   {
     return hardware_interface::return_type::OK;
   }


### PR DESCRIPTION
(Thanks @JafarAbdi for this great ros2 topic library.)

On documentation (https://github.com/PickNikRobotics/topic_based_ros2_control/blob/main/doc/user.md) trigger_joint_command_threshold can be configuration with zero so that the allow publisher to always send the joint command.

However, in the code the condition was set with:
```
  if (diff <= trigger_joint_command_threshold_)
   {
     return hardware_interface::return_type::OK;
   }
```
In case trigger_joint_command_threshold_ is set to zero, diff can still be zero so it will not trigger the send.

This PR tries to address the above mentioned case.