### PR TITLE
Fix RessourceManager constructor

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -20,15 +20,13 @@ jobs:
       fail-fast: false
       matrix:
         env:
-          - CI_NAME: build-and-test
-          # TODO: Enable clang-tidy it's failing to errors unrelated to this repo
-          # - CI_NAME: clang-tidy
-          #  CLANG_TIDY: true
+          - ROS_DISTRO: jazzy
+          - ROS_DISTRO: humble
+          - ROS_DISTRO: rolling
 
     env:
       CCACHE_DIR: /github/home/.ccache
       CXXFLAGS: "-Wall -Wextra -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls"
-      ROS_DISTRO: humble
       ROS_REPO: main
 
     runs-on: ubuntu-latest

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -1,7 +1,7 @@
 # This config uses industrial_ci (https://github.com/ros-industrial/industrial_ci.git).
 # For troubleshooting, see readme (https://github.com/ros-industrial/industrial_ci/blob/master/README.rst)
 
-name: Build and Test (humble)
+name: Build and Test
 
 # This determines when this workflow is run
 on:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,12 @@ if(BUILD_TESTING)
   target_link_libraries(topic_based_system_test
     ${PROJECT_NAME})
   ament_target_dependencies(topic_based_system_test ${THIS_PACKAGE_INCLUDE_DEPENDS} ros2_control_test_assets)
+  target_compile_definitions(
+    topic_based_system_test
+    PRIVATE
+      HARDWARE_INTERFACE_VERSION_MAJOR=${hardware_interface_VERSION_MAJOR}
+      HARDWARE_INTERFACE_VERSION_MINOR=${hardware_interface_VERSION_MINOR}
+      HARDWARE_INTERFACE_VERSION_PATCH=${hardware_interface_VERSION_PATCH})
 endif()
 
 pluginlib_export_plugin_description_file(hardware_interface topic_based_ros2_control_plugin_description.xml)

--- a/test/topic_based_system_test.cpp
+++ b/test/topic_based_system_test.cpp
@@ -33,6 +33,7 @@
 
 #include <gtest/gtest.h>
 #include <hardware_interface/resource_manager.hpp>
+#include <rclcpp/node.hpp>
 #include <rclcpp/utilities.hpp>
 #include <rclcpp_lifecycle/state.hpp>
 #include <ros2_control_test_assets/descriptions.hpp>
@@ -63,7 +64,9 @@ TEST(TestTopicBasedSystem, load_topic_based_system_2dof)
 )";
   auto urdf = ros2_control_test_assets::urdf_head + hardware_system_2dof_standard_interfaces_with_topic_based +
               ros2_control_test_assets::urdf_tail;
-  ASSERT_NO_THROW(hardware_interface::ResourceManager rm(urdf, true, false));
+  auto node = std::make_shared<rclcpp::Node>("test_topic_based_system");
+  ASSERT_NO_THROW(hardware_interface::ResourceManager rm(urdf, node->get_node_clock_interface(),
+                                                         node->get_node_logging_interface(), false));
 }
 
 int main(int argc, char** argv)

--- a/test/topic_based_system_test.cpp
+++ b/test/topic_based_system_test.cpp
@@ -38,6 +38,10 @@
 #include <rclcpp_lifecycle/state.hpp>
 #include <ros2_control_test_assets/descriptions.hpp>
 
+#define VERSION_GREATER_EQUAL(major1, minor1, patch1, major2, minor2, patch2)                                          \
+  ((major1) > (major2) ||                                                                                              \
+   ((major1) == (major2) && ((minor1) > (minor2) || ((minor1) == (minor2) && (patch1) >= (patch2)))))
+
 TEST(TestTopicBasedSystem, load_topic_based_system_2dof)
 {
   const std::string hardware_system_2dof_standard_interfaces_with_topic_based =
@@ -65,8 +69,15 @@ TEST(TestTopicBasedSystem, load_topic_based_system_2dof)
   auto urdf = ros2_control_test_assets::urdf_head + hardware_system_2dof_standard_interfaces_with_topic_based +
               ros2_control_test_assets::urdf_tail;
   auto node = std::make_shared<rclcpp::Node>("test_topic_based_system");
+
+// The API of the RessourceManager has changed in hardware_interface 4.13.0
+#if VERSION_GREATER_EQUAL(HARDWARE_INTERFACE_VERSION_MAJOR, HARDWARE_INTERFACE_VERSION_MINOR,                          \
+                          HARDWARE_INTERFACE_VERSION_PATCH, 4, 13, 0)
   ASSERT_NO_THROW(hardware_interface::ResourceManager rm(urdf, node->get_node_clock_interface(),
                                                          node->get_node_logging_interface(), false));
+#else
+  ASSERT_NO_THROW(hardware_interface::ResourceManager rm(urdf, true, false));
+#endif
 }
 
 int main(int argc, char** argv)


### PR DESCRIPTION
I'm currently working on a CI job with downstream builds for ros2_control, and this package here fails.

The API of the RessourceManager has changed. To be able to compile this repository on jazzy+rolling, one has to pass some more arguments to it. I think it is time to branch-off humble and fix that for the newer distros.