### PR TITLE
Fix deprecation warning from hardware interface.

### DIFF
--- a/include/topic_based_ros2_control/topic_based_system.hpp
+++ b/include/topic_based_ros2_control/topic_based_system.hpp
@@ -55,7 +55,7 @@ using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface
 class TopicBasedSystem : public hardware_interface::SystemInterface
 {
 public:
-  CallbackReturn on_init(const hardware_interface::HardwareInfo& info) override;
+  CallbackReturn on_init(const hardware_interface::HardwareComponentInterfaceParams& params) override;
 
   std::vector<hardware_interface::StateInterface> export_state_interfaces() override;
 


### PR DESCRIPTION
Similar to https://github.com/JafarAbdi/feetech_ros2_driver/pull/14.

I'm currently working on a [jazzy patch sync](https://discourse.openrobotics.org/t/preparing-for-jazzy-sync-and-patch-release-2025-08-14) and this package is [under a regression error](https://repo.ros2.org/status_page/ros_jazzy_default.html?q=REGRESSION) due to a deprecation in the `ros2_control` hardware interface and since this package has [enabled warnings as errors](https://github.com/PickNikRobotics/topic_based_ros2_control/blob/8ba98de35987b13b6db849a574ec0a51cdb442cb/CMakeLists.txt#L5). To avoid the wipe out of the package in `jazzy` with the coming sync I suggest we merge this fix and release a new version containing the changes to `jazzy`.
 
This PR is a fix to avoid the warning by updating to the `on_init` signature from `const hardware_interface::HardwareInfo& info` to `const hardware_interface::HardwareComponentInterfaceParams& params`. Additionally it also updates all references to access hardware info via params.hardware_info (e.g., params.hardware_info.hardware_parameters, params.hardware_info.joints)

Alternatively you can remove the [warnings as errors option](https://github.com/PickNikRobotics/topic_based_ros2_control/blob/8ba98de35987b13b6db849a574ec0a51cdb442cb/CMakeLists.txt#L5) but I guess updating is a good move forward.

**After we apply the fix we need a release to `jazzy` on the [rosdistro](https://github.com/ros/rosdistro).**