### PR TITLE
Changes to enable other controllers for Isaac Sim

### DIFF
--- a/include/topic_based_ros2_control/topic_based_system.hpp
+++ b/include/topic_based_ros2_control/topic_based_system.hpp
@@ -45,7 +45,7 @@
 #include <rclcpp/node.hpp>
 #include <rclcpp/publisher.hpp>
 #include <rclcpp/subscription.hpp>
-
+#include <std_msgs/msg/bool.hpp>
 #include <sensor_msgs/msg/joint_state.hpp>
 
 namespace topic_based_ros2_control
@@ -68,8 +68,11 @@ public:
 private:
   rclcpp::Subscription<sensor_msgs::msg::JointState>::SharedPtr topic_based_joint_states_subscriber_;
   rclcpp::Publisher<sensor_msgs::msg::JointState>::SharedPtr topic_based_joint_commands_publisher_;
+  // Add a new subscriber for a signal whether to stop publishing joint commands.
+  rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr stop_joint_commands_subscriber_;
   rclcpp::Node::SharedPtr node_;
   sensor_msgs::msg::JointState latest_joint_state_;
+  bool stop_joint_commands_{ false };
   bool sum_wrapped_joint_states_{ false };
 
   /// Use standard interfaces for joints because they are relevant for dynamic behavior


### PR DESCRIPTION
1. Currently topic based control spams the last seen messages onto the topic.
2. Now, this change will enable a user to toggle on/off this controller using ROS2 topics.